### PR TITLE
Add PineScript Assistant Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pinev6
 
-This repository contains a Chrome extension, **PineScript Assistant**, that helps analyze Pine scripts directly on TradingView using the OpenAI API.
+This repository contains a Chrome extension, **PineScript Assistant**, that helps analyze Pine scripts directly on
+TradingView using the OpenAI API.
 
 ## Setup
 
@@ -11,4 +12,5 @@ This repository contains a Chrome extension, **PineScript Assistant**, that help
 
 ## Usage
 
-Navigate to a TradingView chart. A panel appears in the top-right corner with an **Analyze code** button. Clicking it sends the current editor contents and a screenshot to OpenAI and displays recommendations in the panel.
+Navigate to a TradingView chart. A draggable panel appears in the top-right corner with an **Analyze code** button. Clicking it sends the current editor contents and a screenshot to OpenAI and displays recommendations in the panel. The panel can be moved or closed as needed.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # pinev6
+
+This repository contains a Chrome extension, **PineScript Assistant**, that helps analyze Pine scripts directly on TradingView using the OpenAI API.
+
+## Setup
+
+1. Obtain an OpenAI API key.
+2. In Chrome, open `chrome://extensions` and enable **Developer mode**.
+3. Choose **Load unpacked** and select this folder.
+4. Click the extension icon and enter your API key in the popup.
+
+## Usage
+
+Navigate to a TradingView chart. A panel appears in the top-right corner with an **Analyze code** button. Clicking it sends the current editor contents and a screenshot to OpenAI and displays recommendations in the panel.

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ TradingView using the OpenAI API.
 
 ## Usage
 
-Navigate to a TradingView chart. A draggable panel appears in the top-right corner with an **Analyze code** button. Clicking it sends the current editor contents and a screenshot to OpenAI and displays recommendations in the panel. The panel can be moved or closed as needed.
+Navigate to a TradingView chart. A draggable panel appears in the top-right corner with an **Analyze code** button. Clicking it sends the current editor contents and recent console output to OpenAI and displays recommendations in the panel. The panel can be moved or closed as needed.
 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,49 @@
+// Service worker for PineScript Assistant
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'analyze') {
+    handleAnalysis(message.code, sender.tab.id).then(sendResponse);
+    return true; // Keep the message channel open for async response
+  }
+});
+
+async function handleAnalysis(code, tabId) {
+  try {
+    const screenshot = await chrome.tabs.captureVisibleTab(tabId, { format: 'png' });
+    const { apiKey } = await chrome.storage.sync.get('apiKey');
+    if (!apiKey) {
+      return { error: 'API key not set. Open the extension popup to provide your key.' };
+    }
+
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        input: [
+          {
+            role: 'user',
+            content: [
+              { type: 'input_text', text: `Analyze this Pine script and provide recommendations:\n${code}` },
+              { type: 'input_image', image_url: screenshot }
+            ]
+          }
+        ]
+      })
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      return { error: `API error: ${err}` };
+    }
+
+    const data = await response.json();
+    const text = data.output?.[0]?.content?.[0]?.text || 'No response received.';
+    return { text };
+  } catch (err) {
+    return { error: err.message };
+  }
+}

--- a/background.js
+++ b/background.js
@@ -2,15 +2,13 @@
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'analyze') {
-    const windowId = sender.tab.windowId;
-    handleAnalysis(message.code, windowId).then(sendResponse);
+    handleAnalysis(message.code, message.consoleLog).then(sendResponse);
     return true; // Keep the message channel open for async response
   }
 });
 
-async function handleAnalysis(code, windowId) {
+async function handleAnalysis(code, consoleLog) {
   try {
-    const screenshot = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
     const { apiKey } = await chrome.storage.sync.get('apiKey');
     if (!apiKey) {
       return { error: 'API key not set. Open the extension popup to provide your key.' };
@@ -28,8 +26,10 @@ async function handleAnalysis(code, windowId) {
           {
             role: 'user',
             content: [
-              { type: 'input_text', text: `Analyze this Pine script and provide recommendations:\n${code}` },
-              { type: 'input_image', image_url: screenshot }
+              {
+                type: 'input_text',
+                text: `Analyze this Pine script and provide recommendations.\n\nCode:\n${code}\n\nConsole output:\n${consoleLog}`
+              }
             ]
           }
         ]

--- a/background.js
+++ b/background.js
@@ -2,14 +2,15 @@
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'analyze') {
-    handleAnalysis(message.code, sender.tab.id).then(sendResponse);
+    const windowId = sender.tab.windowId;
+    handleAnalysis(message.code, windowId).then(sendResponse);
     return true; // Keep the message channel open for async response
   }
 });
 
-async function handleAnalysis(code, tabId) {
+async function handleAnalysis(code, windowId) {
   try {
-    const screenshot = await chrome.tabs.captureVisibleTab(tabId, { format: 'png' });
+    const screenshot = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
     const { apiKey } = await chrome.storage.sync.get('apiKey');
     if (!apiKey) {
       return { error: 'API key not set. Open the extension popup to provide your key.' };

--- a/content.js
+++ b/content.js
@@ -1,20 +1,41 @@
 // Inject overlay UI onto TradingView pages
 
+const PANEL_ID = 'pine-assistant-panel';
+
 function createPanel() {
+  if (document.getElementById(PANEL_ID)) return;
+
   const panel = document.createElement('div');
-  panel.id = 'pine-assistant-panel';
+  panel.id = PANEL_ID;
   panel.style.position = 'fixed';
   panel.style.top = '10px';
   panel.style.right = '10px';
   panel.style.zIndex = '10000';
   panel.style.background = '#fff';
   panel.style.border = '1px solid #ccc';
+  panel.style.borderRadius = '4px';
   panel.style.padding = '8px';
   panel.style.fontSize = '12px';
-  panel.style.width = '250px';
+  panel.style.width = '260px';
   panel.style.boxShadow = '0 2px 8px rgba(0,0,0,0.3)';
 
+  const header = document.createElement('div');
+  header.textContent = 'Pine Assistant';
+  header.style.cursor = 'move';
+  header.style.fontWeight = 'bold';
+  header.style.marginBottom = '8px';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '×';
+  closeBtn.style.float = 'right';
+  closeBtn.style.border = 'none';
+  closeBtn.style.background = 'transparent';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.addEventListener('click', () => panel.remove());
+  header.appendChild(closeBtn);
+
   const btn = document.createElement('button');
+  btn.id = 'pine-analyze-btn';
   btn.textContent = 'Analyze code';
   btn.style.width = '100%';
 
@@ -24,30 +45,86 @@ function createPanel() {
   output.style.maxHeight = '300px';
   output.style.overflowY = 'auto';
   output.style.marginTop = '8px';
+  output.style.background = '#f6f6f6';
+  output.style.padding = '4px';
 
   btn.addEventListener('click', analyzeCode);
 
+  panel.appendChild(header);
   panel.appendChild(btn);
   panel.appendChild(output);
   document.body.appendChild(panel);
+
+  makeDraggable(panel, header);
+}
+
+function makeDraggable(panel, handle) {
+  let isDown = false;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  handle.addEventListener('mousedown', (e) => {
+    isDown = true;
+    offsetX = e.clientX - panel.offsetLeft;
+    offsetY = e.clientY - panel.offsetTop;
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+
+  function onMouseMove(e) {
+    if (!isDown) return;
+    panel.style.left = `${e.clientX - offsetX}px`;
+    panel.style.top = `${e.clientY - offsetY}px`;
+    panel.style.right = '';
+  }
+
+  function onMouseUp() {
+    isDown = false;
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  }
 }
 
 function extractPineScript() {
-  // Attempt to locate TradingView's code editor textarea
-  const textarea = document.querySelector('textarea[id^="codeEditor"]') || document.querySelector('textarea');
+  if (window.monaco?.editor) {
+    const model = window.monaco.editor.getModels()[0];
+    if (model) return model.getValue();
+  }
+
+  const cm = document.querySelector('.CodeMirror');
+  if (cm && cm.CodeMirror) {
+    return cm.CodeMirror.getValue();
+  }
+
+  const textarea =
+    document.querySelector('textarea[id^="codeEditor"]') ||
+    document.querySelector('textarea');
   return textarea ? textarea.value : '';
 }
 
 async function analyzeCode() {
-  const code = extractPineScript();
+  const btn = document.getElementById('pine-analyze-btn');
   const output = document.getElementById('pine-assistant-output');
-  output.textContent = 'Analyzing…';
-  const response = await chrome.runtime.sendMessage({ type: 'analyze', code });
-  if (response.error) {
-    output.textContent = 'Error: ' + response.error;
-  } else {
-    output.textContent = response.text;
+  const code = extractPineScript();
+
+  btn.disabled = true;
+  btn.textContent = 'Analyzing…';
+  output.textContent = '';
+
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'analyze', code });
+    if (response.error) {
+      output.textContent = 'Error: ' + response.error;
+    } else {
+      output.textContent = response.text;
+    }
+  } catch (err) {
+    output.textContent = 'Error: ' + err.message;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Analyze code';
   }
 }
 
 createPanel();
+

--- a/content.js
+++ b/content.js
@@ -1,0 +1,53 @@
+// Inject overlay UI onto TradingView pages
+
+function createPanel() {
+  const panel = document.createElement('div');
+  panel.id = 'pine-assistant-panel';
+  panel.style.position = 'fixed';
+  panel.style.top = '10px';
+  panel.style.right = '10px';
+  panel.style.zIndex = '10000';
+  panel.style.background = '#fff';
+  panel.style.border = '1px solid #ccc';
+  panel.style.padding = '8px';
+  panel.style.fontSize = '12px';
+  panel.style.width = '250px';
+  panel.style.boxShadow = '0 2px 8px rgba(0,0,0,0.3)';
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Analyze code';
+  btn.style.width = '100%';
+
+  const output = document.createElement('pre');
+  output.id = 'pine-assistant-output';
+  output.style.whiteSpace = 'pre-wrap';
+  output.style.maxHeight = '300px';
+  output.style.overflowY = 'auto';
+  output.style.marginTop = '8px';
+
+  btn.addEventListener('click', analyzeCode);
+
+  panel.appendChild(btn);
+  panel.appendChild(output);
+  document.body.appendChild(panel);
+}
+
+function extractPineScript() {
+  // Attempt to locate TradingView's code editor textarea
+  const textarea = document.querySelector('textarea[id^="codeEditor"]') || document.querySelector('textarea');
+  return textarea ? textarea.value : '';
+}
+
+async function analyzeCode() {
+  const code = extractPineScript();
+  const output = document.getElementById('pine-assistant-output');
+  output.textContent = 'Analyzing…';
+  const response = await chrome.runtime.sendMessage({ type: 'analyze', code });
+  if (response.error) {
+    output.textContent = 'Error: ' + response.error;
+  } else {
+    output.textContent = response.text;
+  }
+}
+
+createPanel();

--- a/content.js
+++ b/content.js
@@ -102,17 +102,29 @@ function extractPineScript() {
   return textarea ? textarea.value : '';
 }
 
+const capturedLogs = [];
+const originalConsoleLog = console.log;
+console.log = (...args) => {
+  capturedLogs.push(args.map(String).join(' '));
+  originalConsoleLog.apply(console, args);
+};
+
+function extractConsoleLog() {
+  return capturedLogs.join('\n');
+}
+
 async function analyzeCode() {
   const btn = document.getElementById('pine-analyze-btn');
   const output = document.getElementById('pine-assistant-output');
   const code = extractPineScript();
+  const consoleLog = extractConsoleLog();
 
   btn.disabled = true;
   btn.textContent = 'Analyzing…';
   output.textContent = '';
 
   try {
-    const response = await chrome.runtime.sendMessage({ type: 'analyze', code });
+    const response = await chrome.runtime.sendMessage({ type: 'analyze', code, consoleLog });
     if (response.error) {
       output.textContent = 'Error: ' + response.error;
     } else {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,10 @@
   "version": "0.1.0",
   "description": "Analyze Pine scripts on TradingView using OpenAI.",
   "permissions": ["storage", "activeTab", "scripting", "tabs"],
-  "host_permissions": ["https://*.tradingview.com/*"],
+  "host_permissions": [
+    "https://*.tradingview.com/*",
+    "https://api.openai.com/*"
+  ],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "PineScript Assistant",
+  "version": "0.1.0",
+  "description": "Analyze Pine scripts on TradingView using OpenAI.",
+  "permissions": ["storage", "activeTab", "scripting", "tabs"],
+  "host_permissions": ["https://*.tradingview.com/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "PineScript Assistant",
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*.tradingview.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>PineScript Assistant</title>
+  <style>
+    body { width: 300px; font-family: Arial, sans-serif; padding: 10px; }
+    label { display: block; margin-bottom: 8px; }
+    input { width: 100%; box-sizing: border-box; }
+    #status { margin-top: 8px; color: green; }
+  </style>
+</head>
+<body>
+  <h1>PineScript Assistant</h1>
+  <label>OpenAI API Key
+    <input type="password" id="apiKey" placeholder="sk-..." />
+  </label>
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const apiKeyInput = document.getElementById('apiKey');
+  const status = document.getElementById('status');
+
+  chrome.storage.sync.get('apiKey', (data) => {
+    if (data.apiKey) {
+      apiKeyInput.value = data.apiKey;
+    }
+  });
+
+  document.getElementById('save').addEventListener('click', () => {
+    const apiKey = apiKeyInput.value.trim();
+    chrome.storage.sync.set({ apiKey }, () => {
+      status.textContent = 'Saved';
+      setTimeout(() => (status.textContent = ''), 2000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement Manifest V3 extension that injects a panel into TradingView pages and calls a service worker for analysis
- service worker captures a screenshot, sends code and image to OpenAI, and returns recommendations
- popup page stores the user's API key for authenticated requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c1277d1483258f23bfe7f8730509