### PR TITLE
feat: capture logs and optional screenshot

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,42 @@
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+  if (message.type === 'execute_pine') {
+    const { pineCode, consoleLog, includeScreenshot } = message;
+
+    const inputs = [
+      { type: 'input_pine', text: pineCode },
+    ];
+
+    if (consoleLog) {
+      inputs.push({ type: 'input_text', text: consoleLog });
+    }
+
+    if (includeScreenshot) {
+      try {
+        const screenshot = await chrome.tabs.captureVisibleTab(
+          sender.tab.windowId,
+          { format: 'png' }
+        );
+        inputs.push({
+          type: 'input_image',
+          image_base64: screenshot.split(',')[1],
+        });
+      } catch (err) {
+        console.error('Screenshot failed', err);
+      }
+    }
+
+    try {
+      const response = await fetch('https://example.com/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inputs }),
+      });
+      const data = await response.json();
+      sendResponse({ ok: true, data });
+    } catch (err) {
+      console.error('Execution failed', err);
+      sendResponse({ ok: false, error: String(err) });
+    }
+    return true;
+  }
+});


### PR DESCRIPTION
## Summary
- add background script that forwards Pine code and console logs
- optionally capture screenshot and attach to request
- send textual logs as `input_text`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c674dd5c83258a934dbdf9a4b3bf